### PR TITLE
added component CinecoAlternativo.jsx to the  homepage section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "nanoid": "^3.3.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.8.2",
@@ -12755,9 +12756,15 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "nanoid": "^3.3.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.8.2",

--- a/src/components/CinecoAlternativo/AltCard/AltCard.jsx
+++ b/src/components/CinecoAlternativo/AltCard/AltCard.jsx
@@ -1,0 +1,13 @@
+import React from "react"
+import "./alt-card.scss"
+
+function AltCard({ url, activeName, name }) {
+  return (
+    <div className="card">
+      <img src={url} alt={name} />
+      {activeName && <h4 className="card__title">{name}</h4>}
+    </div>
+  )
+}
+
+export default AltCard

--- a/src/components/CinecoAlternativo/AltCard/alt-card.scss
+++ b/src/components/CinecoAlternativo/AltCard/alt-card.scss
@@ -1,0 +1,16 @@
+.card {
+  padding: 1em;
+  background-color: white;
+  //   border: 1px solid orangered;
+  //   flex: 1;
+  img {
+    max-width: 100%;
+    border-radius: 0.5em;
+  }
+  &__title {
+    color: black;
+    font-weight: 500;
+    font-size: 1.125rem;
+    letter-spacing: 0.45px;
+  }
+}

--- a/src/components/CinecoAlternativo/AltCard/index.js
+++ b/src/components/CinecoAlternativo/AltCard/index.js
@@ -1,0 +1,3 @@
+import AltCard from "./AltCard"
+
+export { AltCard }

--- a/src/components/CinecoAlternativo/AltSection/AltSection.jsx
+++ b/src/components/CinecoAlternativo/AltSection/AltSection.jsx
@@ -1,0 +1,26 @@
+import React from "react"
+import { nanoid } from "nanoid"
+import { AltCard } from "../AltCard"
+
+import "./alt-section.scss"
+
+function AltSection({ title, imagelist, url }) {
+  const displayList = imagelist.map(({ imgUrl, showName, name }) => (
+    <AltCard key={nanoid()} url={imgUrl} activeName={showName} name={name} />
+  ))
+  return (
+    <div className="subsection">
+      <h3 className="subsection__title">{title}</h3>
+      {imagelist && (
+        <div className="subsection__image-container">{displayList}</div>
+      )}
+      {url && (
+        <button type="button" className="subsection__btn-go-to" onClick={url}>
+          Ver todo &gt;
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default AltSection

--- a/src/components/CinecoAlternativo/AltSection/alt-section.scss
+++ b/src/components/CinecoAlternativo/AltSection/alt-section.scss
@@ -1,0 +1,37 @@
+@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap");
+
+.subsection {
+  display: flex;
+  flex-direction: column;
+
+  &__title {
+    margin-block: 1em;
+    font-size: 1.125rem;
+    line-height: 1.125;
+    letter-spacing: 0.25px;
+    font-weight: 500;
+  }
+
+  &__image-container {
+    display: flex;
+    gap: 1em;
+  }
+
+  &__btn-go-to {
+    align-self: flex-end;
+    padding: 1em 1.5em;
+    margin-block: 1em;
+    border: 1px solid #1c508d;
+    background-color: transparent;
+    color: #1c508d;
+    border-radius: 5em;
+    font-size: 1em;
+    font-weight: 500;
+    font-family: "Roboto", sans-serif;
+  }
+
+  &__btn-go-to:hover {
+    background-color: #1c508d;
+    color: white;
+  }
+}

--- a/src/components/CinecoAlternativo/AltSection/index.js
+++ b/src/components/CinecoAlternativo/AltSection/index.js
@@ -1,0 +1,3 @@
+import AltSection from "./AltSection"
+
+export { AltSection }

--- a/src/components/CinecoAlternativo/CinecoAlternativo.jsx
+++ b/src/components/CinecoAlternativo/CinecoAlternativo.jsx
@@ -1,0 +1,38 @@
+import React from "react"
+import "./cineco-alternativo.scss"
+
+import { useNavigate } from "react-router-dom"
+import { AltSection } from "./AltSection"
+
+import {
+  otherImageList,
+  OperaImageList,
+  balletImageList,
+  teatroImageList,
+} from "./MockData/mockData"
+
+function CinecoAlternativo() {
+  const navigate = useNavigate()
+
+  return (
+    <section className="cineco-alternativo">
+      <div className="cineco-alternativo__section-container">
+        <h2 className="cineco-alternativo__title">CINECO ALTERNATIVO</h2>
+        <div className="cineco-alternativo__opera-grid">
+          <AltSection
+            title="Ópera"
+            imagelist={OperaImageList}
+            url={() => navigate("/construccion")}
+          />
+        </div>
+        <div className="cineco-alternativo__others-grid">
+          <AltSection title="Ballet" imagelist={balletImageList} />
+          <AltSection title="Teatro" imagelist={teatroImageList} />
+          <AltSection title="Otros" imagelist={otherImageList} />
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default CinecoAlternativo

--- a/src/components/CinecoAlternativo/MockData/mockData.js
+++ b/src/components/CinecoAlternativo/MockData/mockData.js
@@ -1,0 +1,53 @@
+export const balletImageList = [
+  {
+    imgUrl:
+      "https://archivos-cms.cinecolombia.com/images/7/2/5/6/16527-15-esl-CO/9da627a01ae5-banners_600x400px_ballet.jpg",
+    showName: false,
+    name: "La funcion va a comenzar",
+  },
+]
+
+export const otherImageList = [
+  {
+    imgUrl:
+      "https://archivos-cms.cinecolombia.com/images/1/6/5/6/16561-8-esl-CO/a24bd2c2c48b-banners_600x400px_arte.jpg",
+    showName: false,
+    name: "La historia se ha hecho de las estrellas",
+  },
+]
+
+export const teatroImageList = [
+  {
+    imgUrl:
+      "https://archivos-cms.cinecolombia.com/images/5/4/5/6/16545-8-esl-CO/d030b0977794-microsoftteams-image-51-.png",
+    showName: false,
+    name: "Los espectadores animaran nuestras funciones",
+  },
+]
+
+export const OperaImageList = [
+  {
+    imgUrl:
+      "https://archivos-cms.cinecolombia.com/images/_aliases/poster_card/3/6/5/0/30563-2-esl-CO/8f4b57cedfcc-poster_480x670_6.png",
+    showName: true,
+    name: "Falstaff",
+  },
+  {
+    imgUrl:
+      "https://archivos-cms.cinecolombia.com/images/_aliases/poster_card/7/9/5/0/30597-2-esl-CO/adfc0cec8427-poster_480x670_7.png",
+    showName: true,
+    name: "El Caballero De La Rosa",
+  },
+  {
+    imgUrl:
+      "https://archivos-cms.cinecolombia.com/images/_aliases/poster_card/1/3/6/0/30631-6-esl-CO/3e1dc75dabc6-poster_480x670_8.png",
+    showName: true,
+    name: "Campeón",
+  },
+  {
+    imgUrl:
+      "https://archivos-cms.cinecolombia.com/images/_aliases/poster_card/5/6/6/0/30665-2-esl-CO/b3314d67ab84-poster_480x670_9.png",
+    showName: true,
+    name: "Don Giovanni",
+  },
+]

--- a/src/components/CinecoAlternativo/cineco-alternativo.scss
+++ b/src/components/CinecoAlternativo/cineco-alternativo.scss
@@ -1,0 +1,34 @@
+@import url("https://fonts.googleapis.com/css2?family=Noto+Serif:wght@400;700&display=swap");
+
+.cineco-alternativo {
+  background-color: #f6f6f6;
+  width: 100vw;
+  padding: 2em 4em 1em 4em;
+  font-family: "Noto Serif", serif;
+  display: flex;
+  justify-content: center;
+
+  &__section-container {
+    max-width: 1344px;
+  }
+
+  &__title {
+    font-size: 1.125rem;
+    line-height: 1;
+    letter-spacing: 0.25px;
+    font-weight: 500;
+  }
+
+  &__opera-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    // border: 1px solid blue;
+  }
+
+  &__others-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(min(500px, 100%), 1fr));
+    column-gap: 1em;
+    // border: 1px solid orangered;
+  }
+}

--- a/src/components/CinecoAlternativo/index.js
+++ b/src/components/CinecoAlternativo/index.js
@@ -1,0 +1,3 @@
+import CinecoAlternativo from "./CinecoAlternativo"
+
+export { CinecoAlternativo }

--- a/src/components/LandingBanner/landing-banner.scss
+++ b/src/components/LandingBanner/landing-banner.scss
@@ -29,7 +29,7 @@
       position: absolute;
       top: 5%;
       right: 10%;
-      background-color: steelblue;
+      background-color: #1c508d;
       color: white;
       padding: 0.8em;
       border: none;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,6 +3,7 @@ import { Header } from "../components/Header"
 import { Footer } from "../components/Footer"
 import { PromoSlider } from "../components/PromoSlider"
 import { LandingBanner } from "../components/LandingBanner"
+import { CinecoAlternativo } from "../components/CinecoAlternativo"
 
 function Home() {
   // landing banner initialization
@@ -18,6 +19,7 @@ function Home() {
         url={landingUrl}
       />
       <Header />
+      <CinecoAlternativo />
       <PromoSlider />
       <Footer />
     </>

--- a/src/pages/TestCineco.jsx
+++ b/src/pages/TestCineco.jsx
@@ -1,0 +1,8 @@
+import React from "react"
+import { CinecoAlternativo } from "../components/CinecoAlternativo"
+
+function TestCineco() {
+  return <CinecoAlternativo />
+}
+
+export default TestCineco

--- a/src/router/index.jsx
+++ b/src/router/index.jsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, RouterProvider } from "react-router-dom"
 import { ErrorPage, Home } from "../pages"
 import InProgress from "../pages/InProgress"
+import TestCienco from "../pages/TestCineco"
 
 const routerconfig = createBrowserRouter([
   {
@@ -15,6 +16,10 @@ const routerconfig = createBrowserRouter([
   {
     path: "/construccion",
     element: <InProgress />,
+  },
+  {
+    path: "/testcineco",
+    element: <TestCienco />,
   },
 ])
 


### PR DESCRIPTION
1. El componente CinecoAlternativo.jsx usa dos grid principales. el primero para organizar la sección de ópera y el segundo para organizar las demás secciones.
2. Se usa un componente anidado AltSection.jsx, este recibe el título como parámetro, el listado de imágenes para mostrar y la validación para desplegar un botón de "ver todo" de forma condicional.
3. se usa otro componente anidado AltCard.jsx para renderizar las imágenes. Estas imágenes llegan mediante un prop en un objeto con información de la url y validación si debe o no mostrar el nombre de la imágen.
4. se creó una archivo mockData.js para inicializar el listado imágenes que se deben mostrar en cada sección.
5. Video demostrativo: https://www.loom.com/share/99ff1c850bdd4353bbd6ba8817469d0f